### PR TITLE
Photoshop API SDK should use custom User-Agent header

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,17 @@
       "request": "attach",
       "name": "Attach",
       "port": 9229
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch File",
+      "skipFiles": [
+          "<node_internals>/**"
+      ],
+      "program": "${file}"
+      // ex: "program": "./src/sample/psapi/01_createCutout.js"
+      // ex: "program": "./src/sample/batch_job/remove-background-batch.js"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,6 @@
           "<node_internals>/**"
       ],
       "program": "${file}"
-      // ex: "program": "./src/sample/psapi/01_createCutout.js"
-      // ex: "program": "./src/sample/batch_job/remove-background-batch.js"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-lib-photoshop-api",
   "version": "0.0.4-beta.6",
-  "description": "Adobe Photoshop API Library",
+  "description": "Adobe I/O Photoshop API Library",
   "author": "Adobe Inc.",
   "homepage": "https://github.com/AdobeDocs/photoshop-api-docs",
   "repository": "https://github.com/adobe/aio-lib-photoshop-api",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "redoc-bundle": "redoc-cli bundle spec/api.json -o docs/index.html"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@adobe/aio-lib-core-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-lib-photoshop-api",
   "version": "0.0.4-beta.6",
-  "description": "Adobe I/O Photoshop Automation SDK",
+  "description": "Adobe Photoshop API Library",
   "author": "Adobe Inc.",
   "homepage": "https://github.com/AdobeDocs/photoshop-api-docs",
   "repository": "https://github.com/adobe/aio-lib-photoshop-api",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-lib-photoshop-api",
-  "version": "0.0.4-beta.6",
+  "version": "0.0.4-beta.7",
   "description": "Adobe I/O Photoshop API Library",
   "author": "Adobe Inc.",
   "homepage": "https://github.com/AdobeDocs/photoshop-api-docs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-lib-photoshop-api",
-  "version": "0.0.4-beta.7",
-  "description": "Adobe I/O Photoshop API Library",
+  "version": "0.0.4-beta.6",
+  "description": "Adobe I/O Photoshop Automation SDK",
   "author": "Adobe Inc.",
   "homepage": "https://github.com/AdobeDocs/photoshop-api-docs",
   "repository": "https://github.com/adobe/aio-lib-photoshop-api",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,6 +15,9 @@ const loggerNamespace = 'aio-lib-photoshop-api'
 const logger = require('@adobe/aio-lib-core-logging')(loggerNamespace, { level: process.env.LOG_LEVEL })
 const NodeFetchRetry = require('@adobe/node-fetch-retry')
 
+const { version } = require('../package.json');
+const sdkUserAgentHeader = `Adobe I/O Photoshop API SDK/${version}`
+
 // Wait 1 second for first retry, then 2, 4, etc
 const RETRY_INITIAL_DELAY = 1000
 
@@ -182,6 +185,7 @@ function requestToString (request) {
  * @returns {Request} the request object
  */
 function requestInterceptor (request) {
+  request.headers['User-Agent'] = sdkUserAgentHeader
   logger.debug(`REQUEST:\n ${requestToString(request)}`)
   return request
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,9 +15,6 @@ const loggerNamespace = 'aio-lib-photoshop-api'
 const logger = require('@adobe/aio-lib-core-logging')(loggerNamespace, { level: process.env.LOG_LEVEL })
 const NodeFetchRetry = require('@adobe/node-fetch-retry')
 
-const { version } = require('../package.json');
-const sdkUserAgentHeader = `Adobe I/O Photoshop API SDK/${version}`
-
 // Wait 1 second for first retry, then 2, 4, etc
 const RETRY_INITIAL_DELAY = 1000
 
@@ -181,19 +178,6 @@ function requestToString (request) {
  * A request interceptor that logs the request
  *
  * @private
- * @param {Request} request the request object
- * @returns {Request} the request object
- */
-function requestInterceptor (request) {
-  request.headers['User-Agent'] = sdkUserAgentHeader
-  logger.debug(`REQUEST:\n ${requestToString(request)}`)
-  return request
-}
-
-/**
- * A request interceptor that logs the request
- *
- * @private
  * @param {Response} response the response object
  * @returns {Response} the response object
  */
@@ -206,7 +190,6 @@ module.exports = {
   responseBodyToString,
   requestToString,
   createRequestOptions,
-  requestInterceptor,
   responseInterceptor,
   nodeFetchRetry,
   shouldRetryFetch,

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ class PhotoshopAPI {
 
     this.sdk = await new Swagger(swaggerOptions)
 
-    this.userAgentHeader = (options && options['User-Agent']) || defaultUserAgentHeader
+    this.userAgentHeader = (options && options['User-Agent']) ? options['User-Agent'] : defaultUserAgentHeader
 
     const initErrors = []
     if (!apiKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -121,9 +121,9 @@ class PhotoshopAPI {
     // init swagger client
     const spec = require('../spec/api.json')
 
-    const requestInterceptor = function (request) {
+    const requestInterceptor = request => {
       return this.requestInterceptor(request)
-    }.bind(this)
+    }
 
     const swaggerOptions = {
       spec: spec,
@@ -222,9 +222,9 @@ class PhotoshopAPI {
    * @returns {*} Job status response
    */
   async __getJobStatus (url) {
-    const requestInterceptor = function (request) {
+    const requestInterceptor = request => {
       return this.requestInterceptor(request)
-    }.bind(this)
+    }
 
     const response = await Swagger.http({
       url,

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const { FileResolver } = require('./fileresolver')
 const types = require('./types')
 require('./types')
 
-const { description, version } = require('../package.json');
+const { description, version } = require('../package.json')
 const defaultUserAgentHeader = `${description}/${version}`
 
 /* global EditPhotoOptions Input Output CreateDocumentOptions MimeType ModifyDocumentOptions ReplaceSmartObjectOptions ApplyPhotoshopActionsOptions */
@@ -47,7 +47,6 @@ async function init (orgId, apiKey, accessToken, files, options) {
     throw err
   }
 }
-
 
 /**
  * Translate and throw error

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ class PhotoshopAPI {
 
     this.sdk = await new Swagger(swaggerOptions)
 
-    this.userAgentHeader = (options && options['User-Agent']) ? options['User-Agent'] : defaultUserAgentHeader
+    this.userAgentHeader = (options && options['User-Agent']) || defaultUserAgentHeader
 
     const initErrors = []
     if (!apiKey) {
@@ -200,6 +200,10 @@ class PhotoshopAPI {
    * @returns {Request} the request object
    */
   requestInterceptor (request) {
+    if (!request.headers) {
+      request.headers = {}
+    }
+
     request.headers['User-Agent'] = this.userAgentHeader
     logger.debug(`REQUEST:\n ${requestToString(request)}`)
     return request

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 'use strict'
 
-const { responseBodyToString, requestToString, reduceError, requestInterceptor, responseInterceptor, createRequestOptions, shouldRetryFetch, getFetchOptions } = require('../src/helpers')
+const { responseBodyToString, requestToString, reduceError, responseInterceptor, createRequestOptions, shouldRetryFetch, getFetchOptions } = require('../src/helpers')
 
 test('reduceError', () => {
   // no args produces empty object

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -61,11 +61,6 @@ test('createRequestOptions', () => {
   })
 })
 
-test('requestInterceptor', () => {
-  const req = {}
-  expect(requestInterceptor(req)).toEqual(req)
-})
-
 test('responseInterceptor', async () => {
   const res = {}
   expect(await responseInterceptor(res)).toEqual(res)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,6 +69,19 @@ test('sdk init test - no accessToken', async () => {
   )
 })
 
+test('sdk init test - userAgentHeader not empty', async () => {
+  return expect(Boolean(sdkClient.userAgentHeader)).toBe(true)
+})
+
+test('sdk requestInterceptor test - expected User-Agent header added', async () => {
+  const request = sdkClient.requestInterceptor({
+    url: 'https://foo.bar',
+    headers: {},
+    method: 'PUT'
+  })
+  return expect(Boolean(request.headers['User-Agent'])).toBe(true)
+})
+
 /** @private */
 async function standardTest ({
   fullyQualifiedApiName,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,8 +41,8 @@ const createSwaggerOptions = (body = {}) => {
   })
 }
 
-const createSdkClient = async () => {
-  return sdk.init(gOrgId, gApiKey, gAccessToken)
+const createSdkClient = async (options) => {
+  return sdk.init(gOrgId, gApiKey, gAccessToken, undefined, options)
 }
 
 // /////////////////////////////////////////////
@@ -69,8 +69,19 @@ test('sdk init test - no accessToken', async () => {
   )
 })
 
-test('sdk init test - userAgentHeader not empty', async () => {
+test('sdk init test - userAgentHeader w/o options', async () => {
   return expect(Boolean(sdkClient.userAgentHeader)).toBe(true)
+})
+
+test('sdk init test - with options, but w/o User-Agent', async () => {
+  sdkClient = await createSdkClient({})
+  return expect(Boolean(sdkClient.userAgentHeader)).toBe(true)
+})
+
+test('sdk requestInterceptor test - expected User-Agent header from options', async () => {
+  const ua = 'ua'
+  sdkClient = await createSdkClient({ 'User-Agent': ua })
+  return expect(sdkClient.userAgentHeader).toBe(ua)
 })
 
 test('sdk requestInterceptor test - expected User-Agent header added', async () => {


### PR DESCRIPTION
## Description
[[DISE-8621] Photoshop API SDK should use custom User-Agent header

In order to support SDK usage analytics, the SDK should use a custom User-Agent header. Its value is to be used as a marker for analytical purposes.
