### PR TITLE
FEATURE-RELEASE:support for actionJSON Photoshop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ with valid values for orgId, apiKey and accessToken
     * [.createRendition(input, outputs)](#PhotoshopAPI+createRendition) ⇒ [<code>Job</code>](#Job)
     * [.replaceSmartObject(input, outputs, options)](#PhotoshopAPI+replaceSmartObject) ⇒ [<code>Job</code>](#Job)
     * [.applyPhotoshopActions(input, outputs, options)](#PhotoshopAPI+applyPhotoshopActions) ⇒ [<code>Job</code>](#Job)
+    * [.applyPhotoshopActionsJson(input, outputs, options)](#PhotoshopAPI+applyPhotoshopActionsJson) ⇒ [<code>Job</code>](#Job)
 
 <a name="PhotoshopAPI+orgId"></a>
 
@@ -639,7 +640,7 @@ Apply psd edits for replacing embedded smart object and then generate renditions
 <a name="PhotoshopAPI+applyPhotoshopActions"></a>
 
 ### photoshopAPI.applyPhotoshopActions(input, outputs, options) ⇒ [<code>Job</code>](#Job)
-Apply Photoshop Actions and then generate renditions and/or save a new psd
+Apply Photoshop Actions and then generate renditions and/or save a new image
 
 **Kind**: instance method of [<code>PhotoshopAPI</code>](#PhotoshopAPI)  
 **Returns**: [<code>Job</code>](#Job) - Photoshop Actions job  
@@ -649,6 +650,20 @@ Apply Photoshop Actions and then generate renditions and/or save a new psd
 | input | [<code>Input</code>](#Input) | An object describing an input image file. Current support is for files less than 1000MB. |
 | outputs | <code>string</code> \| [<code>Output</code>](#Output) \| [<code>Array.&lt;Output&gt;</code>](#Output) | Desired output |
 | options | <code>ApplyPhotoshopActionsOptions</code> | Apply Photoshop Actions options |
+
+<a name="PhotoshopAPI+applyPhotoshopActionsJson"></a>
+
+### photoshopAPI.applyPhotoshopActionsJson(input, outputs, options) ⇒ [<code>Job</code>](#Job)
+Apply JSON-formatted Photoshop Actions and then generate renditions and/or save a new image
+
+**Kind**: instance method of [<code>PhotoshopAPI</code>](#PhotoshopAPI)  
+**Returns**: [<code>Job</code>](#Job) - Photoshop Actions job  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| input | [<code>Input</code>](#Input) | An object describing an input image file. Current support is for files less than 1000MB. |
+| outputs | <code>string</code> \| [<code>Output</code>](#Output) \| [<code>Array.&lt;Output&gt;</code>](#Output) | Desired output |
+| options | <code>ApplyPhotoshopActionsJsonOptions</code> | Apply Photoshop Actions JSON options |
 
 <a name="Job"></a>
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -441,7 +441,7 @@
       }
     },
     "/pie/psdService/documentOperations": {
-      "summary": "Initiates an asynchronous job to apply (optional) psd edits and then generate renditions and/or save as a new image",
+      "summary": "Initiates an asynchronous job to apply (optional) psd edits and then generate renditions and/or save as a new psd",
       "post": {
         "operationId": "modifyDocument",
         "tags": ["photoshop"],
@@ -545,7 +545,7 @@
       }
     },
     "/pie/psdService/smartObject": {
-      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save as a new image",
+      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save as a new psd",
       "post": {
         "operationId": "replaceSmartObject",
         "tags": ["photoshop"],
@@ -1807,7 +1807,6 @@
         "properties": {
           "inputs": {
             "type": "array",
-            "required": "true",
             "description": "An array of input objects. We currently only support one input object",
             "items": {
               "$ref": "#/components/schemas/input"
@@ -1815,7 +1814,6 @@
           },
           "outputs": {
             "type": "array",
-            "required": "true",
             "description": "An array of output objects",
             "items": {
               "$ref": "#/components/schemas/photoshopOutput"
@@ -1823,10 +1821,8 @@
           },
           "options": {
             "type": "object",
-            "required": "true",
             "properties": {
               "actionJSON": {
-                "required": "true",
                 "$ref": "#/components/schemas/actions_json"
               },
               "patterns": {
@@ -1838,7 +1834,7 @@
               "brushes": {
                 "$ref": "#/components/schemas/brushes"
               },
-              "additionalImagess": {
+              "additionalImages": {
                 "$ref": "#/components/schemas/additional_images"
               }
 
@@ -1988,7 +1984,7 @@
       },
       "options_asset": {
         "type": "object",
-        "description": "An object describing the input custom font, brush, pattern or.",
+        "description": "An object describing the input custom font, brush or pattern.",
         "properties": {
           "storage": {
             "type": "string",
@@ -2004,7 +2000,6 @@
       },
       "actions_json": {
         "type": "array",
-        "required": "true",
         "description": "array of Photoshop JSON-formatted Actions to play",
         "items": {
           "$ref": "#/components/schemas/action_json"

--- a/spec/api.json
+++ b/spec/api.json
@@ -545,7 +545,7 @@
       }
     },
     "/pie/psdService/smartObject": {
-      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save as a new psd",
+      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save a new psd",
       "post": {
         "operationId": "replaceSmartObject",
         "tags": ["photoshop"],

--- a/spec/api.json
+++ b/spec/api.json
@@ -441,7 +441,7 @@
       }
     },
     "/pie/psdService/documentOperations": {
-      "summary": "Initiates an asynchronous job to apply (optional) psd edits and then generate renditions and/or save a new psd",
+      "summary": "Initiates an asynchronous job to apply (optional) psd edits and then generate renditions and/or save as a new image",
       "post": {
         "operationId": "modifyDocument",
         "tags": ["photoshop"],
@@ -545,7 +545,7 @@
       }
     },
     "/pie/psdService/smartObject": {
-      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save a new psd",
+      "summary": "Initiates an asynchronous job to apply psd edits for replacing embedded smart object and then generate renditions and/or save as a new image",
       "post": {
         "operationId": "replaceSmartObject",
         "tags": ["photoshop"],
@@ -597,7 +597,7 @@
       }
     },
     "/pie/psdService/photoshopActions": {
-      "summary": "Initiates an asynchronous job to play Photoshop Actions and then generate renditions and/or save a new psd",
+      "summary": "Initiates an asynchronous job to play Photoshop Actions and then generate renditions and/or save as a new image",
       "post": {
         "operationId": "applyPhotoshopActions",
         "tags": [
@@ -617,6 +617,63 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/photoshopActionsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jobStatusLinkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "401": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "403": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "404": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "415": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "500": {
+            "$ref": "#/components/schemas/errors"
+          }
+        }
+      }
+    },
+    "/pie/psdService/actionJSON": {
+      "summary": "Initiates an asynchronous job to play JSON-formatted Photoshop Actions and then generate renditions and/or save as a new image",
+      "post": {
+        "operationId": "applyPhotoshopActionsJson",
+        "tags": [
+          "photoshop"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/x-gw-ims-org-id"
+          },
+          {
+            "$ref": "#/components/parameters/json-content-type"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/photoshopActionJsonRequest"
               }
             }
           }
@@ -1745,6 +1802,50 @@
           }
         }
       },
+      "photoshopActionJsonRequest": {
+        "type": "object",
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "required": "true",
+            "description": "An array of input objects. We currently only support one input object",
+            "items": {
+              "$ref": "#/components/schemas/input"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "required": "true",
+            "description": "An array of output objects",
+            "items": {
+              "$ref": "#/components/schemas/photoshopOutput"
+            }
+          },
+          "options": {
+            "type": "object",
+            "required": "true",
+            "properties": {
+              "actionJSON": {
+                "required": "true",
+                "$ref": "#/components/schemas/actions_json"
+              },
+              "patterns": {
+                "$ref": "#/components/schemas/patterns"
+              },
+              "fonts": {
+                "$ref": "#/components/schemas/fonts"
+              },
+              "brushes": {
+                "$ref": "#/components/schemas/brushes"
+              },
+              "additionalImagess": {
+                "$ref": "#/components/schemas/additional_images"
+              }
+
+            }
+          }
+        }
+      },
       "document": {
         "type": "object",
         "properties": {
@@ -1845,23 +1946,14 @@
         "type": "array",
         "description": "array of custom fonts needed in this document",
         "items": {
-          "$ref": "#/components/schemas/font"
+          "$ref": "#/components/schemas/options_asset"
         }
       },
-      "font": {
-        "type": "object",
-        "description": "An object describing the input font to add or replace for a Text layer. Filename should be <font_postscript_name>.otf.\n If the font filename is not in the specified format above, font substitution will occur",
-        "properties": {
-          "storage": {
-            "type": "string",
-            "description": "storage platforms supported",
-            "enum": ["adobe", "external", "azure", "dropbox"],
-            "default": "adobe"
-          },
-          "href": {
-            "type": "string",
-            "description": "Either a Creative Cloud assets path for storage=\"adobe\" OR a presignedGETURL"
-          }
+      "brushes": {
+        "type": "array",
+        "description": "array of custom brushes needed in this document",
+        "items": {
+          "$ref": "#/components/schemas/options_asset"
         }
       },
       "actions": {
@@ -1891,12 +1983,12 @@
         "type": "array",
         "description": "array of custom pattern preset to be used in Photoshop Actions",
         "items": {
-          "$ref": "#/components/schemas/pattern"
+          "$ref": "#/components/schemas/options_asset"
         }
       },
-      "pattern": {
+      "options_asset": {
         "type": "object",
-        "description": "An object describing the input custom preset for a pattern.",
+        "description": "An object describing the input custom font, brush, pattern or.",
         "properties": {
           "storage": {
             "type": "string",
@@ -1906,8 +1998,28 @@
           },
           "href": {
             "type": "string",
-            "description": "Either a Creative Cloud assets path for storage=\"adobe\" OR a presignedGETURL"
+            "description": "Either a Creative Cloud assets path for storage=\"adobe\" OR a presigned GET URL"
           }
+        }
+      },
+      "actions_json": {
+        "type": "array",
+        "required": "true",
+        "description": "array of Photoshop JSON-formatted Actions to play",
+        "items": {
+          "$ref": "#/components/schemas/action_json"
+        }
+      },
+      "action_json": {
+        "type": "object",
+        "description": "An object describing a single Photoshop Actions JSON command."
+      },
+      "additional_images": {
+        "type": "array",
+        "minItems": 1,
+        "description": "array of references to additional images, which can be referred by actionJson commands",
+        "items": {
+          "$ref": "#/components/schemas/input"
         }
       },
       "adjustmentLayer": {

--- a/src/fileresolver.js
+++ b/src/fileresolver.js
@@ -251,6 +251,9 @@ class FileResolver {
     if (options && options.patterns) {
       options.patterns = await this.resolveInputs(options.patterns)
     }
+    if (options && options.brushes) {
+      options.brushes = await this.resolveInputs(options.brushes)
+    }
     return options
   }
 

--- a/src/fileresolver.js
+++ b/src/fileresolver.js
@@ -254,6 +254,9 @@ class FileResolver {
     if (options && options.brushes) {
       options.brushes = await this.resolveInputs(options.brushes)
     }
+    if (options && options.additionalImages) {
+      options.additionalImages = await this.resolveInputs(options.additionalImages)
+    }
     return options
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -537,7 +537,7 @@ class PhotoshopAPI {
   }
 
   /**
-   * Apply Photoshop Actions and then generate renditions and/or save a new psd
+   * Apply Photoshop Actions and then generate renditions and/or save a new image
    *
    * @param {Input} input An object describing an input image file. Current support is for files less than 1000MB.
    * @param {string|Output|Output[]} outputs Desired output
@@ -547,6 +547,31 @@ class PhotoshopAPI {
   async applyPhotoshopActions (input, outputs, options) {
     try {
       const response = await this.sdk.apis.photoshop.applyPhotoshopActions({
+        'x-gw-ims-org-id': this.orgId
+      }, this.__createRequestOptions({
+        inputs: await this.fileResolver.resolveInputs(input),
+        outputs: await this.fileResolver.resolveOutputs(outputs),
+        options: await this.fileResolver.resolveInputsPhotoshopActionsOptions(options)
+      }))
+
+      const job = new Job(response.body, this.__getJobStatus.bind(this))
+      return await job.pollUntilDone()
+    } catch (err) {
+      throwError(err)
+    }
+  }
+
+  /**
+   * Apply JSON-formatted Photoshop Actions and then generate renditions and/or save a new image
+   *
+   * @param {Input} input An object describing an input image file. Current support is for files less than 1000MB.
+   * @param {string|Output|Output[]} outputs Desired output
+   * @param {ApplyPhotoshopActionsJsonOptions} options Apply Photoshop Actions JSON options
+   * @returns {Job} Photoshop Actions job
+   */
+  async applyPhotoshopActionsJson (input, outputs, options) {
+    try {
+      const response = await this.sdk.apis.photoshop.applyPhotoshopActionsJson({
         'x-gw-ims-org-id': this.orgId
       }, this.__createRequestOptions({
         inputs: await this.fileResolver.resolveInputs(input),

--- a/src/index.js
+++ b/src/index.js
@@ -566,7 +566,7 @@ class PhotoshopAPI {
    *
    * @param {Input} input An object describing an input image file. Current support is for files less than 1000MB.
    * @param {string|Output|Output[]} outputs Desired output
-   * @param {ApplyPhotoshopActionsJsonOptions} options Apply Photoshop Actions JSON options
+   * @param {ApplyPhotoshopActionsOptions} options Apply Photoshop Actions options
    * @returns {Job} Photoshop Actions job
    */
   async applyPhotoshopActionsJson (input, outputs, options) {

--- a/test/fileresolver.test.js
+++ b/test/fileresolver.test.js
@@ -416,6 +416,19 @@ test('resolveInputsPhotoshopActionsOptionsPatterns', async () => {
   })
 })
 
+test('resolveInputsPhotoshopActionsOptionsBrushes', async () => {
+  const resolver = new FileResolver()
+  const result = await resolver.resolveInputsPhotoshopActionsOptions({
+    brushes: ['https://host/path/to/brush.abr']
+  })
+  expect(result).toEqual({
+    brushes: [{
+      href: 'https://host/path/to/brush.abr',
+      storage: 'external'
+    }]
+  })
+})
+
 test('resolveInputsValue', async () => {
   const resolver = new FileResolver()
   const result = await resolver.resolveInputs('https://host/path/to/file.png')

--- a/test/fileresolver.test.js
+++ b/test/fileresolver.test.js
@@ -429,6 +429,19 @@ test('resolveInputsPhotoshopActionsOptionsBrushes', async () => {
   })
 })
 
+test('resolveInputsPhotoshopActionsJsonOptionsAdditionalImages', async () => {
+  const resolver = new FileResolver()
+  const result = await resolver.resolveInputsPhotoshopActionsOptions({
+    additionalImages: ['https://host/path/to/additional_image.png']
+  })
+  expect(result).toEqual({
+    additionalImages: [{
+      href: 'https://host/path/to/additional_image.png',
+      storage: 'external'
+    }]
+  })
+})
+
 test('resolveInputsValue', async () => {
   const resolver = new FileResolver()
   const result = await resolver.resolveInputs('https://host/path/to/file.png')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1585,4 +1585,96 @@ describe('Photoshop', () => {
       }
     })
   })
+
+  describe('applyPhotoshopActionsJson', () => {
+    let spec
+    let apiParameters
+    let apiOptions
+    let sdkArgs
+    let returnValue
+    let jobStatus
+    beforeEach(async () => {
+      apiParameters = { 'x-gw-ims-org-id': gOrgId }
+      apiOptions = createSwaggerOptions({
+        inputs: await sdkClient.fileResolver.resolveInputs('input'),
+        outputs: await sdkClient.fileResolver.resolveOutputs('outputs'),
+        options: await sdkClient.fileResolver.resolveInputsDocumentOptions('options')
+      })
+      sdkArgs = ['input', 'outputs', 'options']
+
+      spec = {
+        fullyQualifiedApiName: 'photoshop.applyPhotoshopActionsJson',
+        apiParameters: apiParameters,
+        apiOptions: apiOptions,
+        sdkFunctionName: 'applyPhotoshopActionsJson',
+        sdkArgs: sdkArgs
+      }
+
+      returnValue = {
+        body: {
+          _links: {
+            self: { href: 'https://image.adobe.io/sensei/status/fcc4e0fcb-260b-47c3-b520-de0d17dc2b67' }
+          }
+        }
+      }
+
+      jobStatus = {
+        jobID: 'applyPhotoshopActionsJsonSucceededJobId',
+        status: 'succeeded',
+        input: '/files/images/input.jpg',
+        output: {
+          storage: 'adobe',
+          href: '/files/applyPhotoshopActionsJson/output/applyPhotoshopActionsJson.png',
+          mask: {
+            format: 'binary'
+          },
+          color: {
+            space: 'rgb'
+          }
+        },
+        _links: {
+          self: {
+            href: 'https://image.adobe.io/sensei/status/applyPhotoshopJsonActionsSucceededStatusId'
+          }
+        }
+      }
+    })
+
+    test('Success Case', async () => {
+      try {
+        await standardTest({
+          ...spec,
+          returnValue: returnValue,
+          httpResponseBody: jobStatus
+        })
+      } catch (e) {
+        throw e
+      }
+    })
+
+    test('Failure Case', async () => {
+      try {
+        jobStatus.status = 'failed'
+
+        await standardTest({
+          ...spec,
+          returnValue: returnValue,
+          httpResponseBody: jobStatus,
+          status: 'failed'
+        })
+      } catch (e) {
+        throw e
+      }
+    })
+    test('Error Case - Unknown', async () => {
+      try {
+        await errorTest({
+          ...spec,
+          ErrorClass: codes.ERROR_UNKNOWN
+        })
+      } catch (e) {
+        throw e
+      }
+    })
+  })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -237,13 +237,21 @@ declare class PhotoshopAPI {
      */
     replaceSmartObject(input: Input, outputs: string | Output | Output[], options: ReplaceSmartObjectOptions): Job;
     /**
-     * Apply Photoshop Actions and then generate renditions and/or save a new psd
+     * Apply Photoshop Actions and then generate renditions and/or save a new image
      * @param input - An object describing an input image file. Current support is for files less than 1000MB.
      * @param outputs - Desired output
      * @param options - Apply Photoshop Actions options
      * @returns Photoshop Actions job
      */
     applyPhotoshopActions(input: Input, outputs: string | Output | Output[], options: ApplyPhotoshopActionsOptions): Job;
+    /**
+     * Apply JSON-formatted Photoshop Actions and then generate renditions and/or save a new image
+     * @param input - An object describing an input image file. Current support is for files less than 1000MB.
+     * @param outputs - Desired output
+     * @param options - Apply Photoshop Actions JSON options
+     * @returns Photoshop Actions job
+     */
+    applyPhotoshopActionsJson(input: Input, outputs: string | Output | Output[], options: ApplyPhotoshopActionsJsonOptions): Job;
 }
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -251,7 +251,7 @@ declare class PhotoshopAPI {
      * @param options - Apply Photoshop Actions JSON options
      * @returns Photoshop Actions job
      */
-    applyPhotoshopActionsJson(input: Input, outputs: string | Output | Output[], options: ApplyPhotoshopActionsJsonOptions): Job;
+    applyPhotoshopActionsJson(input: Input, outputs: string | Output | Output[], options: ApplyPhotoshopActionsOptions): Job;
 }
 
 /**


### PR DESCRIPTION
Adobe introduced actionJSON service, which allows for execution of Photoshop actions in JSON format. See more details https://developer.adobe.com/photoshop/photoshop-api-docs/api/#tag/Photoshop/operation/actionJSON

## Description
- Update schema with actionJSON endpoint and payload description
- Added brushes option for actionJSON and applyPhotoshopActions APIs
- Streamlined schema definitions for all options (fonts, brushes, presets)
- Provided SDK method applyPhotoshopActionsJson
- Updated documentation
- Provided unit tests for actionJSON API

## Motivation and Context
Since actionJSON supports Photoshop actions in JSON format, which is plain text, it offers more flexibility for Photoshop API users and allows for easy integration of Photoshop API with their workflows.

## How Has This Been Tested?
- Tested manually
- Added necessary unit tests coverage

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
